### PR TITLE
feat: support getting information of a document

### DIFF
--- a/StatisticsApi.go
+++ b/StatisticsApi.go
@@ -30,7 +30,7 @@ func (c AppClient) StatisticsGetAllInfo(fileToken, fileType string) *FileStatist
 	query := make(map[string]any)
 	query["file_type"] = fileType
 
-	responseMap := c.Request("get", "open-apis/drive/v1/files/"+fileToken+"/responseMap", query, nil, nil)
+	responseMap := c.Request("get", "open-apis/drive/v1/files/"+fileToken+"/statistics", query, nil, nil)
 
 	if responseMap == nil {
 		logrus.WithFields(logrus.Fields{

--- a/StatisticsApi.go
+++ b/StatisticsApi.go
@@ -4,13 +4,13 @@ import "github.com/sirupsen/logrus"
 
 type FileStatistics struct {
 	// 文档历史访问人数，同一用户（user_id）多次访问按一次计算。
-	Uv int `json:"uv"`
+	Uv float64 `json:"uv"`
 	// 文档历史访问次数，同一用户（user_id）多次访问按多次计算。（注：同一用户相邻两次访问间隔在半小时内视为一次访问）
-	Pv int `json:"pv"`
+	Pv float64 `json:"pv"`
 	// 文档历史点赞总数，若对应的文档类型不支持点赞，返回 -1
-	LikeCount int `json:"like_count"`
+	LikeCount float64 `json:"like_count"`
 	// 时间戳（秒）
-	Timestamp int `json:"timestamp"`
+	Timestamp float64 `json:"timestamp"`
 }
 
 func (c AppClient) NewStatistics(data map[string]any) *FileStatistics {
@@ -18,10 +18,10 @@ func (c AppClient) NewStatistics(data map[string]any) *FileStatistics {
 	// 其中statistics是一个map[string]any
 	statisticsMap := data["statistics"].(map[string]any)
 	return &FileStatistics{
-		Uv:        statisticsMap["uv"].(int),
-		Pv:        statisticsMap["pv"].(int),
-		LikeCount: statisticsMap["like_count"].(int),
-		Timestamp: statisticsMap["timestamp"].(int),
+		Uv:        statisticsMap["uv"].(float64),
+		Pv:        statisticsMap["pv"].(float64),
+		LikeCount: statisticsMap["like_count"].(float64),
+		Timestamp: statisticsMap["timestamp"].(float64),
 	}
 }
 

--- a/StatisticsApi.go
+++ b/StatisticsApi.go
@@ -1,0 +1,44 @@
+package feishuapi
+
+import "github.com/sirupsen/logrus"
+
+type FileStatistics struct {
+	// 文档历史访问人数，同一用户（user_id）多次访问按一次计算。
+	Uv int `json:"uv"`
+	// 文档历史访问次数，同一用户（user_id）多次访问按多次计算。（注：同一用户相邻两次访问间隔在半小时内视为一次访问）
+	Pv int `json:"pv"`
+	// 文档历史点赞总数，若对应的文档类型不支持点赞，返回 -1
+	LikeCount int `json:"like_count"`
+	// 时间戳（秒）
+	Timestamp int `json:"timestamp"`
+}
+
+func (c AppClient) NewStatistics(data map[string]any) *FileStatistics {
+	// data有三个key: file_token, file_type, statistics
+	// 其中statistics是一个map[string]any
+	statisticsMap := data["statistics"].(map[string]any)
+	return &FileStatistics{
+		Uv:        statisticsMap["uv"].(int),
+		Pv:        statisticsMap["pv"].(int),
+		LikeCount: statisticsMap["like_count"].(int),
+		Timestamp: statisticsMap["timestamp"].(int),
+	}
+}
+
+// StatisticsGetAllInfo Get the statistics of a file
+func (c AppClient) StatisticsGetAllInfo(fileToken, fileType string) *FileStatistics {
+	query := make(map[string]any)
+	query["file_type"] = fileType
+
+	responseMap := c.Request("get", "open-apis/drive/v1/files/"+fileToken+"/responseMap", query, nil, nil)
+
+	if responseMap == nil {
+		logrus.WithFields(logrus.Fields{
+			"FileToken": fileToken,
+			"FileType":  fileType,
+		}).Warn("nil responseMap return")
+		return nil
+	}
+
+	return c.NewStatistics(responseMap)
+}


### PR DESCRIPTION
`StatisticsGetAllInfo` allows you to retrieve the statistics of a file.

The function returns a `FileStatistics` struct that contains the following fields:
- uv: The document's historical number of visitors. Multiple visits by the same user are counted as one visit.
- pv: The document's historical number of visits. Multiple visits by the same user are counted as multiple visits.
- like_count: The total number of likes for the document. If the corresponding document type does not support likes, -1 is returned.
- timestamp: Timestamp
